### PR TITLE
Fix constant DAT file reading.

### DIFF
--- a/addons/statustimers/block_native.lua
+++ b/addons/statustimers/block_native.lua
@@ -28,54 +28,60 @@ local helpers = require('helpers');
 -------------------------------------------------------------------------------
 -- local state
 -------------------------------------------------------------------------------
-local handler_data = T { 
-    pointer = T{ nil, nil },
-    opcodes = T{ 0x0000, 0x0000 }
+local handler_data = T {
+    pointer = T{ nil, nil, nil },
+    opcodes = T{ 0x0000, 0x0000, 0x0000 },
 };
+
 -------------------------------------------------------------------------------
 -- exported functions
 -------------------------------------------------------------------------------
 local module = {};
 
 helpers.register_init('block_native_init', function()
-    handler_data.pointer[1] = ashita.memory.find('FFXiMain.dll', 0, '75??55518B0D????????E8????????85C07F??8BDE', 0, 0);
-    handler_data.pointer[2] = ashita.memory.find('FFXiMain.dll', 0, '75??55518B0D????????E8????????85C07F??8BDE', 0, 1);
+    handler_data.pointer[1] = ashita.memory.find('FFXiMain.dll', 0, '75??8B4E0851B9', 0, 0);
+    handler_data.pointer[2] = ashita.memory.find('FFXiMain.dll', 0, '7D??33C05EC20400C6', 0, 0);
+    handler_data.pointer[3] = ashita.memory.find('FFXiMain.dll', 0, '85C00F??????????6A0232DBE8', 0, 0);
 
-    if (handler_data.pointer[1] == 0 or handler_data.pointer[2] == 0) then
+    if (handler_data.pointer[1] == 0 or handler_data.pointer[2] == 0 or handler_data.pointer[3] == 0) then
         return false;
     end
 
-    if (handler_data.pointer[1] == handler_data.pointer[2]) then
-        return false;
-    end
-
-    -- backup the original instructions
+    -- Backup the original instructions..
     handler_data.opcodes[1] = ashita.memory.read_uint16(handler_data.pointer[1]);
     handler_data.opcodes[2] = ashita.memory.read_uint16(handler_data.pointer[2]);
+    handler_data.opcodes[3] = ashita.memory.read_uint16(handler_data.pointer[3]);
 
-    -- check if they have been modified
-    if (handler_data.opcodes[1] ~= 0x9090 and handler_data.opcodes[2] ~= 0x9090) then
-        -- NOP out the branch that draws the native status icons
-        ashita.memory.write_uint16(handler_data.pointer[1], 0x9090);
-        ashita.memory.write_uint16(handler_data.pointer[2], 0x9090);
-        return true;
+    -- Check for previous modifications..
+    if (handler_data.opcodes[1] == 0x9090 or handler_data.opcodes[2] == 0x9090 or handler_data.opcodes[3] == 0xC031) then
+        return false;
     end
-    return false;
---]]
+
+    -- Patch game functions..
+    ashita.memory.write_uint16(handler_data.pointer[1], 0x9090);
+    ashita.memory.write_uint16(handler_data.pointer[2], 0x9090);
+    ashita.memory.write_uint16(handler_data.pointer[3], 0xC031);
+
+    return true;
 end);
 
 helpers.register_cleanup('block_native_cleanup', function()
-    -- revert the NOPs to the original instructions
-    if (handler_data.pointer[1] ~= 0) then
-        if (handler_data.opcodes[1] ~= 0x0000) then
-            ashita.memory.write_uint16(handler_data.pointer[1], handler_data.opcodes[1]);
-        end
+    if (handler_data.pointer[1] ~= 0 and handler_data.opcodes[1] ~= 0) then
+        ashita.memory.write_uint16(handler_data.pointer[1], handler_data.opcodes[1]);
+        handler_data.pointer[1] = 0;
+        handler_data.opcodes[1] = 0;
     end
 
-    if (handler_data.pointer[2] ~= 0) then
-        if (handler_data.opcodes[2] ~= 0x0000) then
-            ashita.memory.write_uint16(handler_data.pointer[2], handler_data.opcodes[2]);
-        end
+    if (handler_data.pointer[2] ~= 0 and handler_data.opcodes[2] ~= 0) then
+        ashita.memory.write_uint16(handler_data.pointer[2], handler_data.opcodes[2]);
+        handler_data.pointer[2] = 0;
+        handler_data.opcodes[2] = 0;
+    end
+
+    if (handler_data.pointer[3] ~= 0 and handler_data.opcodes[3] ~= 0) then
+        ashita.memory.write_uint16(handler_data.pointer[3], handler_data.opcodes[3]);
+        handler_data.pointer[3] = 0;
+        handler_data.opcodes[3] = 0;
     end
 
     return true;


### PR DESCRIPTION
The current version of `block_native.lua` causes DAT file read thrashing. Due to this, the status icon DAT file is constantly being read multiple times per-frame (based on the number of buffs on the player/target party member) which can lead to lag or decreased SSD lifespans.

This commit fixes that issue by allowing the client to handle the DAT file properly, while also fully disabling the rendering of both the local client's status icons and their target party members icons.

This commit also now prevents the keyboard highlighting of the original in-game status icon bar entirely.