### PR TITLE
4.1.6 - Replace deprecated SetWindowFontScale calls for Ashita 4.30+

### DIFF
--- a/addons/statustimers/conf_ui.lua
+++ b/addons/statustimers/conf_ui.lua
@@ -65,7 +65,7 @@ module.render_config_ui = function(settings, toggle)
     imgui.SetNextWindowContentSize({ 500 * scale_w, 760 * scale_h });
 
     if (imgui.Begin(('Statustimers v%s %s'):fmt(addon.version, compat.state()), ui.is_open, ImGuiWindowFlags_AlwaysAutoResize)) then
-        imgui.SetWindowFontScale(ui.ui_scale);
+        imgui.PushFont(nil, imgui.GetFontSize()*ui.ui_scale);
         imgui.BeginGroup();
             -- icon sizes and theme
             imgui.TextColored(header_color, 'Icon Settings');
@@ -213,6 +213,7 @@ module.render_config_ui = function(settings, toggle)
             imgui.TextDisabled(('\xef\x87\xb9 %s by %s'):fmt(os.date('%Y'), addon.author));
             imgui.TextDisabled(('-- %s'):fmt(addon.link));
         imgui.EndGroup();
+        imgui.PopFont();
     end
     imgui.End();
 

--- a/addons/statustimers/main_ui.lua
+++ b/addons/statustimers/main_ui.lua
@@ -284,13 +284,13 @@ local function render_tooltip(status, is_target, for_keyboard_target)
                 draw_rect(bg[1], bg[2], ui.color.label_bg, 0.0, true, 0);
                 draw_rect(bg[1], bg[2], ui.color.label_bg, 0.0, true, 0);
 
-                imgui.SetWindowFontScale(settings.ui_scale);
+                imgui.PushFont(nil, imgui.GetFontSize()*settings.ui_scale);
                 imgui.SetCursorPos({ imgui.GetCursorPosX() + 4, imgui.GetCursorPosY() + 6 });
                 imgui.Text(tip_name);
                 imgui.Text(tip_desc);
+                imgui.PopFont();
             end
 
-            imgui.SetWindowFontScale(1.0);
             imgui.End();
         end
     end
@@ -418,12 +418,12 @@ local function render_split_bar(split_bar_id, name, status_list, is_locked)
 
     if (imgui.Begin('st_' + split_bar_id, ui.is_open, ui.split_bars[split_bar_id])) then
         ui.im_window = true;
-        imgui.SetWindowFontScale(settings.ui_scale);
+        imgui.PushFont(imgui.GetFontSize()*settings.ui_scale);
         render_target_status(name, status_list, is_locked);
         -- update the window state for the next draw
         ui.split_bars[split_bar_id] = imgui.IsWindowHovered() and ui.window_flags.active or ui.window_flags.inactive;
+        imgui.PopFont();
     end
-    imgui.SetWindowFontScale(1.0);
     imgui.End();
     imgui.PopStyleVar(1);
     ui.im_window = false;
@@ -478,7 +478,7 @@ module.render_main_ui = function(s, status_clicked, settings_clicked)
     imgui.SetNextWindowContentSize(get_window_size());
 
     if (imgui.Begin('st_ui', ui.is_open, ui.window_flags.current)) then
-        imgui.SetWindowFontScale(settings.ui_scale);
+        imgui.PushFont(nil, imgui.GetFontSize() * settings.ui_scale);
 
         ui.im_window = true;
         local item_width, _, text_dim = get_base_sizes():unpack();
@@ -590,7 +590,7 @@ module.render_main_ui = function(s, status_clicked, settings_clicked)
         -- update the window state for the next draw
         ui.window_flags.current = imgui.IsWindowHovered() and ui.window_flags.active or ui.window_flags.inactive;
     end
-    imgui.SetWindowFontScale(1.0);
+    imgui.PopFont();
     imgui.End();
     imgui.PopStyleVar(1);
     ui.im_window = false;

--- a/addons/statustimers/statustimers.lua
+++ b/addons/statustimers/statustimers.lua
@@ -19,7 +19,7 @@
 
 addon.name    = 'statustimers';
 addon.author  = 'heals';
-addon.version = '4.1.503';
+addon.version = '4.1.6';
 addon.desc    = 'Replacement for the default status timer display';
 addon.link    = 'https://github.com/HealsCodes/statustimers';
 


### PR DESCRIPTION
The function SetWindowFontScale was removed from IMGUI, so later versions of Ashita no longer support it. I've replaced it with PushFont/PopFont calls and avoided setting the font parameter, which should be functionally equivalent.