### PR TITLE
Add keyboard navigation

### DIFF
--- a/addons/statustimers/conf_ui.lua
+++ b/addons/statustimers/conf_ui.lua
@@ -210,6 +210,7 @@ module.render_config_ui = function(settings, toggle)
             imgui.TextColored(header_color, 'keyboard Navigation');
             imgui.ShowHelp('Step through your own buffs and cancel one without the mouse.\n' ..
                                 '/bind syntax: ^ ctrl, ! alt, + shift. e.g. ^E, LEFT, NUMPAD4.\n' ..
+                                'Use a pipe character to bind multiple keys, e.g. J|LEFT.\n' ..
                                 'Clear a box to unbind it.');
 
             local keynav_h = #keynav.BINDS * imgui.GetFrameHeightWithSpacing()

--- a/addons/statustimers/conf_ui.lua
+++ b/addons/statustimers/conf_ui.lua
@@ -217,12 +217,12 @@ module.render_config_ui = function(settings, toggle)
 
             imgui.BeginChild('conf_keynav', { 0 * scale_w, keynav_h }, ImGuiChildFlags_Borders)
                 for _, b in ipairs(keynav.BINDS) do
-                    local buffer = T{ settings.key_nav[b.key] or '' };
+                    local buffer = T{ settings.key_nav[b.action] or '' };
 
-                    imgui.PushID('keynav#' .. b.key);
+                    imgui.PushID('keynav#' .. b.action);
                     imgui.PushItemWidth(120 * scale_w);
                     if (imgui.InputText('', buffer, 32)) then
-                        settings.key_nav[b.key] = buffer[1];
+                        settings.key_nav[b.action] = buffer[1];
                     end
 
                     -- rebind once the box is done, not on every keystroke

--- a/addons/statustimers/conf_ui.lua
+++ b/addons/statustimers/conf_ui.lua
@@ -28,6 +28,7 @@ local helpers = require('helpers');
 local resources = require('resources');
 local filters_ui = require('conf_filters_ui');
 local compat = require('compat');
+local keynav = require('keynav');
 -------------------------------------------------------------------------------
 -- local state
 -------------------------------------------------------------------------------
@@ -62,7 +63,7 @@ module.render_config_ui = function(settings, toggle)
     local scale_w = math.max(1.0, ui.ui_scale * 1.0);
     local scale_h = math.max(1.0, ui.ui_scale * 0.74);
 
-    imgui.SetNextWindowContentSize({ 500 * scale_w, 760 * scale_h });
+    imgui.SetNextWindowContentSize({ 500 * scale_w, 915 * scale_h });
 
     if (imgui.Begin(('Statustimers v%s %s'):fmt(addon.version, compat.state()), ui.is_open, ImGuiWindowFlags_AlwaysAutoResize)) then
         imgui.PushFont(nil, imgui.GetFontSize()*ui.ui_scale);
@@ -203,6 +204,36 @@ module.render_config_ui = function(settings, toggle)
                     settings.split_bars.enabled = not settings.split_bars.enabled;
                 end
                 imgui.ShowHelp('Detach target, subtarget and locked target from the main UI.');
+            imgui.EndChild();
+
+            -- buff selection binds
+            imgui.TextColored(header_color, 'keyboard Navigation');
+            imgui.ShowHelp('Step through your own buffs and cancel one without the mouse.\n' ..
+                                '/bind syntax: ^ ctrl, ! alt, + shift. e.g. ^E, LEFT, NUMPAD4.\n' ..
+                                'Clear a box to unbind it.');
+
+            local keynav_h = #keynav.BINDS * imgui.GetFrameHeightWithSpacing()
+                           + imgui.GetStyle().WindowPadding.y * 2;
+
+            imgui.BeginChild('conf_keynav', { 0 * scale_w, keynav_h }, ImGuiChildFlags_Borders)
+                for _, b in ipairs(keynav.BINDS) do
+                    local buffer = T{ settings.key_nav[b.key] or '' };
+
+                    imgui.PushID('keynav#' .. b.key);
+                    imgui.PushItemWidth(120 * scale_w);
+                    if (imgui.InputText('', buffer, 32)) then
+                        settings.key_nav[b.key] = buffer[1];
+                    end
+
+                    -- rebind once the box is done, not on every keystroke
+                    if (imgui.IsItemDeactivatedAfterEdit()) then
+                        keynav.rebind();
+                    end
+                    imgui.PopItemWidth();
+                    imgui.PopID();
+                    imgui.SameLine();
+                    imgui.Text(b.label);
+                end
             imgui.EndChild();
 
             imgui.TextDisabled(('\xef\x87\xb9 %s by %s'):fmt(os.date('%Y'), addon.author));

--- a/addons/statustimers/keynav.lua
+++ b/addons/statustimers/keynav.lua
@@ -1,0 +1,244 @@
+--[[
+* statustimers - Copyright (c) 2022-2026 Heals
+*
+* This file is part of statustimers for Ashita.
+*
+* statustimers is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* statustimers is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with statustimers.  If not, see <https://www.gnu.org/licenses/>.
+--]]
+
+-------------------------------------------------------------------------------
+-- imports
+-------------------------------------------------------------------------------
+require('common');
+local chat = require('chat');
+local party = require('party');
+local resources = require('resources');
+-------------------------------------------------------------------------------
+-- local state
+-------------------------------------------------------------------------------
+local COMMAND = '/statustimers nav ';
+
+-- bind used for navigation, select is the only persistent one
+local BINDS = T{
+    T{ key = 'select',  label = 'Select buffs', default = '^F',     bindstr = '', persistent = true },
+    T{ key = 'left',    label = 'Move left',    default = 'LEFT',   bindstr = '' },
+    T{ key = 'right',   label = 'Move right',   default = 'RIGHT',  bindstr = '' },
+    T{ key = 'confirm', label = 'Cancel buff',  default = 'RETURN', bindstr = '' },
+    T{ key = 'exit',    label = 'Exit',         default = 'ESCAPE', bindstr = '' },
+};
+
+local state = T{ active = false, index = 1 };
+
+local cfg         = T{};
+local cancel_func = nil;
+-------------------------------------------------------------------------------
+-- local functions
+-------------------------------------------------------------------------------
+local function status_count()
+    local list = party.get_player_status();
+    if (list == nil) then
+        return nil, 0;
+    end
+    return list, #list;
+end
+
+local function run(command)
+    AshitaCore:GetChatManager():ExecuteScriptString(command, '', false);
+end
+
+-- use native ashita /bind for our binds
+local function set_bind(bind, active)
+    local bindstr = '';
+
+    if (active) then
+        bindstr = cfg[bind.key] or '';
+    end
+
+    if (bindstr == bind.bindstr) then
+        return;
+    end
+
+    if (bind.bindstr ~= '') then
+        run('/unbind ' .. bind.bindstr);
+    end
+
+    bind.bindstr = bindstr;
+
+    if (bindstr ~= '') then
+        run(('/bind %s %s%s'):fmt(bindstr, COMMAND, bind.key));
+    end
+end
+
+-- confirm the bind is not taken via ashita already
+local function is_taken(kb, bind)
+    local bindstr = cfg[bind.key] or '';
+
+    if (bindstr == '' or bindstr == bind.bindstr) then
+        return false;
+    end
+
+    local key  = bindstr:match('[!^@#+]*(.+)$');
+    local mods = T{};
+
+    for name, prefix in pairs(T{ alt = '!', apps = '#', ctrl = '^', shift = '+', win = '@' }) do
+        mods[name] = bindstr:find(prefix, 1, true) ~= nil;
+    end
+
+    -- default binds use key down
+    local bound = kb:IsBound(kb:S2D(key), true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
+    if (bound) then
+        print(chat.header('statustimers'):append(chat.error(
+            ('%s is already bound, pick another key for %s.'):fmt(bindstr, bind.key))));
+        return true;
+    end
+
+    return false;
+end
+
+
+-- set binds to silent so we dont slam the chat window
+-- cache the old value to reset after
+local function apply()
+    local kb = AshitaCore:GetInputManager():GetKeyboard();
+    if (kb == nil) then
+        return;
+    end
+
+    local current_silent = kb:GetSilentBinds();
+    kb:SetSilentBinds(true);
+
+    for _, b in ipairs(BINDS) do
+        if (is_taken(kb, b)) then
+            break;
+        end
+
+        set_bind(b, b.persistent or state.active);
+    end
+
+    kb:SetSilentBinds(current_silent);
+end
+
+local function set_active(flag)
+    if (state.active == flag) then
+        return;
+    end
+
+    local _, count = status_count();
+    if (flag and count < 1) then
+        print(chat.header('statustimers'):append(chat.error('no status effects to select.')));
+        return;
+    end
+
+    state.active = flag;
+    state.index  = 1;
+    apply();
+end
+
+local function move(delta)
+    local _, count = status_count();
+    if (count < 1) then
+        return;
+    end
+
+    state.index = state.index + delta;
+    if (state.index > count) then
+        state.index = 1;
+    elseif (state.index < 1) then
+        state.index = count;
+    end
+end
+
+local function confirm()
+    local list, count = status_count();
+    local entry = list and list[math.min(state.index, count)];
+    if (entry == nil) then
+        return;
+    end
+
+    if (not resources.status_can_be_cancelled(entry.id)) then
+        print(chat.header('statustimers'):append(chat.warning(
+            ('%s cannot be cancelled.'):fmt(resources.get_status_name(entry.id)))));
+        return;
+    end
+
+    cancel_func(entry.id);
+end
+-------------------------------------------------------------------------------
+-- exported functions
+-------------------------------------------------------------------------------
+local module = {};
+
+module.BINDS = BINDS;
+
+module.stop = function()
+    set_active(false);
+end
+
+local ACTIONS = T{
+    select  = function() set_active(not state.active); end,
+    left    = function() move(-1); end,
+    right   = function() move(1); end,
+    confirm = confirm,
+    exit    = module.stop,
+};
+
+module.defaults = function()
+    local t = T{};
+    for _, b in ipairs(BINDS) do
+        t[b.key] = b.default;
+    end
+    return t;
+end
+
+module.rebind = apply;
+
+module.bind = function(settings, cancel)
+    cfg         = settings.key_nav;
+    cancel_func = cancel;
+
+    apply();
+end
+
+-- execute the action, select is always valid, else check if active
+module.action = function(name)
+    local fn = ACTIONS[name];
+
+    if (fn ~= nil and (name == 'select' or state.active)) then
+        fn();
+    end
+end
+
+-- reset everything
+module.cleanup = function()
+    state.active = false;
+    cfg          = T{};
+    apply();
+end
+
+-- index of the outlined icon
+---@param count number effects rendered this frame
+---@return number|nil
+module.focus_index = function(count)
+    if (not state.active) then
+        return nil;
+    end
+    if (count < 1) then
+        set_active(false);
+        return nil;
+    end
+    state.index = math.min(state.index, count);
+    return state.index;
+end
+
+return module;

--- a/addons/statustimers/keynav.lua
+++ b/addons/statustimers/keynav.lua
@@ -70,7 +70,11 @@ local function parse_keybind(kb, keybind)
         mods[mod] = mod_prefix ~= nil and mod_prefix:find(char, 1, true) ~= nil;
     end
 
-    return kb:S2D(key_name or ''), mods;
+    return kb:S2D((key_name or ''):upper()), mods;
+end
+
+local function each_key(keybind)
+    return keybind:gmatch('[^|%s]+');
 end
 
 local function unbind(kb, action)
@@ -79,29 +83,35 @@ local function unbind(kb, action)
         return;
     end
 
-    local scancode, mods = parse_keybind(kb, current_keybind);
+    for keybind in each_key(current_keybind) do
+        local scancode, mods = parse_keybind(kb, keybind);
 
-    kb:Unbind(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
+        kb:Unbind(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
+    end
+
     state.current_binds[action] = nil;
 end
 
 local function bind(kb, action, pending_keybind)
-    local scancode, mods = parse_keybind(kb, pending_keybind);
-    if (scancode == 0) then
-        print(chat.header('statustimers'):append(chat.error(
-            ('%s is not a valid key for %s.'):fmt(pending_keybind, action))));
-        return;
+    local bound = T{};
+
+    for keybind in each_key(pending_keybind) do
+        local scancode, mods = parse_keybind(kb, keybind);
+        local taken = kb:IsBound(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
+
+        if (scancode == 0) then
+            print(chat.header('statustimers'):append(chat.error(
+                ('%s is not a valid key for %s.'):fmt(keybind, action))));
+        elseif (taken) then
+            print(chat.header('statustimers'):append(chat.error(
+                ('%s is already bound, pick another key for %s.'):fmt(keybind, action))));
+        else
+            kb:Bind(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false, COMMAND .. action);
+            bound[#bound + 1] = keybind;
+        end
     end
 
-    local taken = kb:IsBound(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
-    if (taken) then
-        print(chat.header('statustimers'):append(chat.error(
-            ('%s is already bound, pick another key for %s.'):fmt(pending_keybind, action))));
-        return;
-    end
-
-    kb:Bind(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false, COMMAND .. action);
-    state.current_binds[action] = pending_keybind;
+    state.current_binds[action] = table.concat(bound, '|');
 end
 
 local function pending_bind(b)

--- a/addons/statustimers/keynav.lua
+++ b/addons/statustimers/keynav.lua
@@ -59,13 +59,13 @@ end
 
 -- use native ashita /bind for our binds
 local function set_bind(bind, active)
-    local bindstr = '';
+    local pending_bind = '';
 
     if (active) then
-        bindstr = cfg[bind.key] or '';
+        pending_bind = cfg[bind.key] or '';
     end
 
-    if (bindstr == bind.bindstr) then
+    if (pending_bind == bind.bindstr) then
         return;
     end
 
@@ -73,11 +73,12 @@ local function set_bind(bind, active)
         run('/unbind ' .. bind.bindstr);
     end
 
-    bind.bindstr = bindstr;
-
-    if (bindstr ~= '') then
-        run(('/bind %s %s%s'):fmt(bindstr, COMMAND, bind.key));
+    if (pending_bind ~= '') then
+        run(('/bind %s %s%s'):fmt(pending_bind, COMMAND, bind.key));
     end
+
+    -- save out what bound
+    bind.bindstr = pending_bind;
 end
 
 -- confirm the bind is not taken via ashita already

--- a/addons/statustimers/keynav.lua
+++ b/addons/statustimers/keynav.lua
@@ -22,6 +22,7 @@
 -------------------------------------------------------------------------------
 require('common');
 local chat = require('chat');
+local ffi = require('ffi');
 local party = require('party');
 local resources = require('resources');
 -------------------------------------------------------------------------------
@@ -29,18 +30,25 @@ local resources = require('resources');
 -------------------------------------------------------------------------------
 local COMMAND = '/statustimers nav ';
 
+-- modifier prefixes for ashita binds
+local MODIFIERS = T{ alt = '!', apps = '#', ctrl = '^', shift = '+', win = '@' };
+
 -- bind used for navigation, select is the only persistent one
 local BINDS = T{
-    T{ key = 'select',  label = 'Select buffs', default = '^F',     bindstr = '', persistent = true },
-    T{ key = 'left',    label = 'Move left',    default = 'LEFT',   bindstr = '' },
-    T{ key = 'right',   label = 'Move right',   default = 'RIGHT',  bindstr = '' },
-    T{ key = 'confirm', label = 'Cancel buff',  default = 'RETURN', bindstr = '' },
-    T{ key = 'exit',    label = 'Exit',         default = 'ESCAPE', bindstr = '' },
+    T{ action = 'select',  label = 'Select buffs', default = '^F', persistent = true },
+    T{ action = 'left',    label = 'Move left',    default = 'LEFT' },
+    T{ action = 'right',   label = 'Move right',   default = 'RIGHT' },
+    T{ action = 'confirm', label = 'Cancel buff',  default = 'RETURN' },
+    T{ action = 'exit',    label = 'Exit',         default = 'ESCAPE' },
 };
 
-local state = T{ active = false, index = 1 };
+local state = T{
+    active        = false,
+    index         = 1,
+    cfg           = T{},
+    current_binds = T{},
+};
 
-local cfg         = T{};
 local cancel_func = nil;
 -------------------------------------------------------------------------------
 -- local functions
@@ -53,64 +61,64 @@ local function status_count()
     return list, #list;
 end
 
-local function run(command)
-    AshitaCore:GetChatManager():ExecuteScriptString(command, '', false);
-end
+-- parse ashita keybind format into scancodes
+local function parse_keybind(kb, keybind)
+    local mod_prefix, key_name = keybind:match('^([!#%^%+@]*)(.+)$');
+    local mods = T{};
 
--- use native ashita /bind for our binds
-local function set_bind(bind, active)
-    local pending_bind = '';
-
-    if (active) then
-        pending_bind = cfg[bind.key] or '';
+    for mod, char in pairs(MODIFIERS) do
+        mods[mod] = mod_prefix ~= nil and mod_prefix:find(char, 1, true) ~= nil;
     end
 
-    if (pending_bind == bind.bindstr) then
+    return kb:S2D(key_name or ''), mods;
+end
+
+local function unbind(kb, action)
+    local current_keybind = state.current_binds[action];
+    if (current_keybind == nil) then
         return;
     end
 
-    if (bind.bindstr ~= '') then
-        run('/unbind ' .. bind.bindstr);
-    end
+    local scancode, mods = parse_keybind(kb, current_keybind);
 
-    if (pending_bind ~= '') then
-        run(('/bind %s %s%s'):fmt(pending_bind, COMMAND, bind.key));
-    end
-
-    -- save out what bound
-    bind.bindstr = pending_bind;
+    kb:Unbind(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
+    state.current_binds[action] = nil;
 end
 
--- confirm the bind is not taken via ashita already
-local function is_taken(kb, bind)
-    local bindstr = cfg[bind.key] or '';
-
-    if (bindstr == '' or bindstr == bind.bindstr) then
-        return false;
-    end
-
-    local key  = bindstr:match('[!^@#+]*(.+)$');
-    local mods = T{};
-
-    for name, prefix in pairs(T{ alt = '!', apps = '#', ctrl = '^', shift = '+', win = '@' }) do
-        mods[name] = bindstr:find(prefix, 1, true) ~= nil;
-    end
-
-    -- default binds use key down
-    local bound = kb:IsBound(kb:S2D(key), true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
-    if (bound) then
+local function bind(kb, action, pending_keybind)
+    local scancode, mods = parse_keybind(kb, pending_keybind);
+    if (scancode == 0) then
         print(chat.header('statustimers'):append(chat.error(
-            ('%s is already bound, pick another key for %s.'):fmt(bindstr, bind.key))));
-        return true;
+            ('%s is not a valid key for %s.'):fmt(pending_keybind, action))));
+        return;
     end
 
-    return false;
+    local taken = kb:IsBound(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false);
+    if (taken) then
+        print(chat.header('statustimers'):append(chat.error(
+            ('%s is already bound, pick another key for %s.'):fmt(pending_keybind, action))));
+        return;
+    end
+
+    kb:Bind(scancode, true, mods.alt, mods.apps, mods.ctrl, mods.shift, mods.win, false, false, COMMAND .. action);
+    state.current_binds[action] = pending_keybind;
 end
 
+local function pending_bind(b)
+    if (state.active or b.persistent) then
+        return state.cfg[b.action] or '';
+    end
+
+    return '';
+end
+
+local function current_bind(b)
+    return state.current_binds[b.action] or '';
+end
 
 -- set binds to silent so we dont slam the chat window
 -- cache the old value to reset after
-local function apply()
+local function update_binds()
     local kb = AshitaCore:GetInputManager():GetKeyboard();
     if (kb == nil) then
         return;
@@ -120,11 +128,16 @@ local function apply()
     kb:SetSilentBinds(true);
 
     for _, b in ipairs(BINDS) do
-        if (is_taken(kb, b)) then
-            break;
-        end
+        local pending = pending_bind(b);
 
-        set_bind(b, b.persistent or state.active);
+        -- only update the keys that are changing
+        if (pending ~= current_bind(b)) then
+            unbind(kb, b.action);
+
+            if (pending ~= '') then
+                bind(kb, b.action, pending);
+            end
+        end
     end
 
     kb:SetSilentBinds(current_silent);
@@ -143,7 +156,7 @@ local function set_active(flag)
 
     state.active = flag;
     state.index  = 1;
-    apply();
+    update_binds();
 end
 
 local function move(delta)
@@ -197,18 +210,18 @@ local ACTIONS = T{
 module.defaults = function()
     local t = T{};
     for _, b in ipairs(BINDS) do
-        t[b.key] = b.default;
+        t[b.action] = b.default;
     end
     return t;
 end
 
-module.rebind = apply;
+module.rebind = update_binds;
 
 module.bind = function(settings, cancel)
-    cfg         = settings.key_nav;
+    state.cfg   = settings.key_nav;
     cancel_func = cancel;
 
-    apply();
+    update_binds();
 end
 
 -- execute the action, select is always valid, else check if active
@@ -223,8 +236,8 @@ end
 -- reset everything
 module.cleanup = function()
     state.active = false;
-    cfg          = T{};
-    apply();
+    state.cfg    = T{};
+    update_binds();
 end
 
 -- index of the outlined icon
@@ -241,5 +254,18 @@ module.focus_index = function(count)
     state.index = math.min(state.index, count);
     return state.index;
 end
+
+-- ashita skips the unload event for addons that error out, so lean on the gc
+-- finalizer as a last chance to hand these keys back to the game
+module.gc = ffi.gc(ffi.cast('uint8_t*', 0), function()
+    local kb = AshitaCore:GetInputManager():GetKeyboard();
+    if (kb == nil) then
+        return;
+    end
+
+    for action in pairs(state.current_binds) do
+        unbind(kb, action);
+    end
+end);
 
 return module;

--- a/addons/statustimers/main_ui.lua
+++ b/addons/statustimers/main_ui.lua
@@ -29,6 +29,7 @@ local chat = require('chat');
 local helpers   = require('helpers');
 local resources = require('resources');
 local party     = require('party');
+local keynav    = require('keynav');
 -------------------------------------------------------------------------------
 -- local constants
 -------------------------------------------------------------------------------
@@ -249,7 +250,8 @@ end
 -- render the tooltip for a specific status id
 ---@param status number the status id
 ---@param is_target boolean if true, don't show '(right click to cancel)' hint
-local function render_tooltip(status, is_target)
+---@param pos table|nil screen position to pin it to, defaults to the mouse
+local function render_tooltip(status, is_target, pos)
     if (status == nil or status < 1 or status > 0x3FF or status == 255) then
         return;
     end
@@ -260,6 +262,9 @@ local function render_tooltip(status, is_target)
     local tip_desc = info.Description[1] or '???';
 
     if (name ~= nil and info ~= nil) then
+        if (pos ~= nil) then
+            imgui.SetNextWindowPos(pos);
+        end
         -- render a regular ImGUI tooltip attached to the mouse
         imgui.BeginTooltip();
             imgui.Text(tip_name);
@@ -443,6 +448,8 @@ module.render_main_ui = function(s, status_clicked, settings_clicked)
     ui.color.va._25   = helpers.color_u32_to_v4(settings.visual_aid.color25);
 
     if (should_hide_ui()) then
+        -- never keep swallowing input while the bar is invisible (cutscenes, map, ...)
+        keynav.stop();
         return;
     end
 
@@ -458,7 +465,13 @@ module.render_main_ui = function(s, status_clicked, settings_clicked)
         ui.im_window = true;
         local item_width, _, text_dim = get_base_sizes():unpack();
         local player_status = party.get_player_status();
-        local is_targeting_buff_menu = resources.get_menu_is_buff_menu();
+        local nav_index = keynav.focus_index(player_status ~= nil and #player_status or 0);
+        -- keyboard navigation pins the tooltip under the bar instead of the cursor
+        local nav_tip;
+        if (nav_index ~= nil) then
+            local x, y = imgui.GetWindowPos();
+            nav_tip = { x, y + select(2, imgui.GetWindowSize()) };
+        end
 
         -- render the player status
         if (player_status ~= nil) then
@@ -483,10 +496,17 @@ module.render_main_ui = function(s, status_clicked, settings_clicked)
                 imgui.BeginGroup();
                     local icon_tint = { 1.0, 1.0, 1.0, ui.id_states[player_status[i].id].alpha }
                     imgui.SetCursorPosX(imgui.GetCursorPosX() + ((item_width - icon_size_main()) * 0.5));
+
+                    if (i == nav_index) then
+                        draw_rect({ -item_spacing(), -item_spacing() },
+                            { icon_size_main() + item_spacing(), icon_size_main() + item_spacing() },
+                            ui.color.locked_border, 7.0, false);
+                    end
+
                     imgui.Image(icon, { icon_size_main(), icon_size_main() }, { 0, 0 }, { 1, 1 }, icon_tint, { 0, 0, 0, 0});
 
-                    if (imgui.IsItemHovered()) then
-                        render_tooltip(player_status[i].id, false);
+                    if (imgui.IsItemHovered() or i == nav_index) then
+                        render_tooltip(player_status[i].id, false, i == nav_index and nav_tip or nil);
                     end
 
                     -- this dummy is essential for correct resizing as it always has the actual item_width

--- a/addons/statustimers/statustimers.lua
+++ b/addons/statustimers/statustimers.lua
@@ -34,6 +34,7 @@ require('block_native');
 local helpers = require('helpers');
 local main_ui = require('main_ui');
 local conf_ui = require('conf_ui');
+local keynav = require('keynav');
 -------------------------------------------------------------------------------
 -- local state
 -------------------------------------------------------------------------------
@@ -50,6 +51,8 @@ local default_settings = T{
         color = 0xFFFFFFFF,
         background = 0x72000000,
     },
+
+    key_nav = keynav.defaults(),
 
     visual_aid = T{
         enabled  = false,
@@ -103,6 +106,8 @@ settings.register('settings', 'settings_update', function (s)
         st.settings = s;
     end
 
+    keynav.bind(st.settings, try_cancel);
+
     -- Save the current settings..
     settings.save();
 end);
@@ -110,9 +115,11 @@ end);
 local ffi = require('ffi');
 ashita.events.register('load', 'statustimers_load', function ()
     helpers.run_init();
+    keynav.bind(st.settings, try_cancel);
 end)
 
 ashita.events.register('unload', 'statustimers_unload', function ()
+    keynav.cleanup();
     settings.save();
     helpers.run_cleanup();
 end)
@@ -135,7 +142,11 @@ ashita.events.register('command', 'statustimers_command', function (e)
     e.blocked = true;
 
     if (args[1] == '/statustimers' or args[1] == '/stt') then
-        toggle_settings();
+        if (args[2] == 'nav' and #args > 2) then
+            keynav.action(args[3]);
+        else
+            toggle_settings();
+        end
     elseif (args[1] == '/lockstatus') then
         if (#args == 1) then
             print(chat.header(addon.name):append(chat.error(('/lockstatus requires a party member name'))));


### PR DESCRIPTION
Hi Heals!

Thanks for all you do, I am a huge fan of this project. I wanted to take a stab at keyboard navigation as I missed it a lot in the most recent edition and I wanted to learn how the Ashita bind API works a bit more. 

I decided not to re-invent the wheel with binds here and just use Ashita. In a nutshell it does this:
* Binds the select buffs keybind on load or config save
* When the above keybind is pressed we ad-hoc bind right/left/enter/esc
* On esc we unbind the tmp ones

This allows us to block input on those binds (right arrow does not hit the game camera when in select mode). But also allows all other keys to work freely, so you can cancel buffs while running, etc. Same functionality as before.

The bind system is the same normal Ashita bind stuff, so modifier and keys. I added some light protection around over binding any binds that people may have in their `scripts/default.txt`.

I am 1000% fine if you don't want to go this direction and trash it, but it was a great learning for me and a fun night.

<img width="517" height="956" alt="status-timers" src="https://github.com/user-attachments/assets/d7a53f7b-2efc-4ca8-add0-23a260251d1e" />


https://github.com/user-attachments/assets/0b7d92ff-0210-44fe-a010-16b593c3a65b